### PR TITLE
Updated first KQL script

### DIFF
--- a/Kusto/Azure Resource Graph/Starter Kit - ASC Recommendations/README.md
+++ b/Kusto/Azure Resource Graph/Starter Kit - ASC Recommendations/README.md
@@ -6,7 +6,7 @@ This starter kit consists of a set of basic ARG queries that have been created t
 
 1. **Get ASC recommendations** in a useful format
 ```
-securityresource
+securityresources
  | where type == "microsoft.security/assessments"
  // Get recommendations in useful format
  | project


### PR DESCRIPTION
The kql under "1. Get ASC recommendations in a useful format" should start with "securityresources" instead of "securityresource" to work properly. Otherwise it would give error.

At Microsoft-Defender-for-Cloud/Kusto/Azure Resource Graph/Starter Kit - ASC Recommendations/